### PR TITLE
Update golang.org/x/text to 0.3.3 - Fix CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-playground/locales
 
 go 1.13
 
-require golang.org/x/text v0.3.2
+require golang.org/x/text v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,3 @@
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This PR is a simple minor version bump to https://pkg.go.dev/golang.org/x/text which fixes [CVE-2020-14040](https://nvd.nist.gov/vuln/detail/CVE-2020-14040). You can see that release [here](https://github.com/golang/text/releases/tag/v0.3.3).

All tests still pass after updating this dependency.