### PR TITLE
Reformat en locale time formatting to fix issue for 12:00 AM formatting

### DIFF
--- a/en/en.go
+++ b/en/en.go
@@ -498,10 +498,9 @@ func (en *en) FmtTimeShort(t time.Time) string {
 
 	b := make([]byte, 0, 32)
 
-	h := t.Hour()
-
-	if h > 12 {
-		h -= 12
+	h := t.Hour() % 12
+	if h == 0 {
+		h = 12
 	}
 
 	b = strconv.AppendInt(b, int64(h), 10)
@@ -528,10 +527,9 @@ func (en *en) FmtTimeMedium(t time.Time) string {
 
 	b := make([]byte, 0, 32)
 
-	h := t.Hour()
-
-	if h > 12 {
-		h -= 12
+	h := t.Hour() % 12
+	if h == 0 {
+		h = 12
 	}
 
 	b = strconv.AppendInt(b, int64(h), 10)
@@ -565,10 +563,9 @@ func (en *en) FmtTimeLong(t time.Time) string {
 
 	b := make([]byte, 0, 32)
 
-	h := t.Hour()
-
-	if h > 12 {
-		h -= 12
+	h := t.Hour() % 12
+	if h == 0 {
+		h = 12
 	}
 
 	b = strconv.AppendInt(b, int64(h), 10)
@@ -607,10 +604,9 @@ func (en *en) FmtTimeFull(t time.Time) string {
 
 	b := make([]byte, 0, 32)
 
-	h := t.Hour()
-
-	if h > 12 {
-		h -= 12
+	h := t.Hour() % 12
+	if h == 0 {
+		h = 12
 	}
 
 	b = strconv.AppendInt(b, int64(h), 10)

--- a/en/en_test.go
+++ b/en/en_test.go
@@ -687,6 +687,10 @@ func TestFmtTimeFull(t *testing.T) {
 			t:        time.Date(2016, 02, 03, 20, 5, 1, 0, fixed),
 			expected: "8:05:01 pm OTHER",
 		},
+		{
+			t:        time.Date(2016, 02, 03, 0, 0, 1, 0, loc),
+			expected: "12:00:01 am Eastern Standard Time",
+		},
 	}
 
 	trans := New()
@@ -718,6 +722,10 @@ func TestFmtTimeLong(t *testing.T) {
 			t:        time.Date(2016, 02, 03, 20, 5, 1, 0, loc),
 			expected: "8:05:01 pm EST",
 		},
+		{
+			t:        time.Date(2016, 02, 03, 0, 0, 1, 0, loc),
+			expected: "12:00:01 am EST",
+		},
 	}
 
 	trans := New()
@@ -744,6 +752,10 @@ func TestFmtTimeMedium(t *testing.T) {
 			t:        time.Date(2016, 02, 03, 20, 5, 1, 0, time.UTC),
 			expected: "8:05:01 pm",
 		},
+		{
+			t:        time.Date(2016, 02, 03, 0, 0, 1, 0, time.UTC),
+			expected: "12:00:01 am",
+		},
 	}
 
 	trans := New()
@@ -769,6 +781,10 @@ func TestFmtTimeShort(t *testing.T) {
 		{
 			t:        time.Date(2016, 02, 03, 20, 5, 1, 0, time.UTC),
 			expected: "8:05 pm",
+		},
+		{
+			t:        time.Date(2016, 02, 03, 0, 0, 1, 0, time.UTC),
+			expected: "12:00 am",
 		},
 	}
 


### PR DESCRIPTION
**Description:**

This issue addresses a bug which was raised in #41 . Please see the issue comments for further understanding of the conversation around this issue.

TLDR:
According to the [CLDR](https://github.com/unicode-org/cldr-json/blob/858baad63c1d51e1d576ef99dccc229d92cedda4/cldr-json/cldr-dates-full/main/en/ca-generic.json#L327) specification the 'en' locale should be formatting the value for 12:00 AM as `12:00 AM` and not `00:00 AM` 

**Changes:**

* FmtTimeShort, FmtTimeMedium, FmtTimeLong and FmtTimeFull now displaying 12 for representing the hour 12:00 AM
* Unit tests added for each of the functions to cover this case.

**Excluded:**

In addition to this, I discovered the same issue exists for a large number of the en locales, any locale which should be formatting hours as the patter `h` as defined by the CLDR spec. I excluded these, due to a large number of unit tests being commented out for those locales. Given I am not aware of the context as to why they are commented out, I didn't want to touch those.

I have created a follow up issue to address this: #45


fixes #41 